### PR TITLE
Error between first name and last name in template generation

### DIFF
--- a/spear/core/mail_campaign_cron.php
+++ b/spear/core/mail_campaign_cron.php
@@ -184,7 +184,7 @@ function InitMailCampaign($conn, $campaign_id){
 	    $keyword_vals['{{RID}}'] = $RID;
 	    $keyword_vals['{{MID}}'] = $campaign_id;
 	    $keyword_vals['{{NAME}}'] = $arr_user['fname'].' '.$arr_user['lname'];
-	    $keyword_vals['{{FNAME}}'] = $arr_user['lname'];
+	    $keyword_vals['{{FNAME}}'] = $arr_user['fname'];
 	    $keyword_vals['{{LNAME}}'] = $arr_user['lname'];
 	    $keyword_vals['{{NOTES}}'] = $arr_user['notes'];
 	    $keyword_vals['{{EMAIL}}'] = $arr_user['email'];


### PR DESCRIPTION
fix first and last name issue when generating email template

![image](https://user-images.githubusercontent.com/37373941/199532450-2f52573e-1160-47c1-aa20-7d1d0644b50f.png)
