### PR TITLE
Update install_manager.php

### DIFF
--- a/install_manager.php
+++ b/install_manager.php
@@ -90,7 +90,7 @@ function getWritePermissionInfo(){
     $resp = [];
     
     if (!is_writable(dirname(__FILE__).'/spear/config'))  //for db.php
-        array_push($resp,dirname(__FILE__).'/spear');
+        array_push($resp,dirname(__FILE__).'/spear/config');
 
     if (!is_writable(dirname(__FILE__).'/spear/uploads'))   //for uploads w.r.t mail
         array_push($resp,dirname(__FILE__).'/spear/uploads');


### PR DESCRIPTION
Corrected permissions check response to request user enable write permission for spear/config folder instead of the entire spear folder. This ensures easier troubleshooting as the install button remains disabled until all requirements are met.