### PR TITLE
Safely detect and set database collation dynamically to avoid CHARSET…

### DIFF
--- a/install_manager.php
+++ b/install_manager.php
@@ -121,6 +121,39 @@ function doInstall(&$POSTJ){
 
     if (mysqli_connect_errno())
         echo json_encode(['error' => "Connection failed: " . mysqli_connect_error()]);
+    
+/* --------------------------------
+   AUTO-DETECT DB TYPE & COLLATION
+--------------------------------- */
+
+function detectDatabaseCollation($conn)
+{
+    $info = strtolower(mysqli_get_server_info($conn));
+
+    // Safe default for MariaDB & MySQL < 8
+    $collation = 'utf8mb4_unicode_ci';
+
+    // MariaDB detection
+    if (strpos($info, 'mariadb') !== false) {
+        return $collation;
+    }
+
+    // MySQL version detection
+    if (preg_match('/(\d+)\./', $info, $matches)) {
+        $major = (int)$matches[1];
+
+        // MySQL 8+
+        if ($major >= 8) {
+            return 'utf8mb4_0900_ai_ci';
+        }
+    }
+
+    return $collation;
+}
+
+mysqli_set_charset($conn, 'utf8mb4');
+$DB_COLLATION = detectDatabaseCollation($conn);
+    
     else
     {
         $file_contents = '<?php
@@ -211,7 +244,7 @@ SET time_zone = "+00:00";
 CREATE TABLE `tb_access_ctrl` (
   `tk_id` varchar(11) NOT NULL,
   `ctrl_ids` varchar(111) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE'.$DB_COLLATION.';
 
 -- --------------------------------------------------------
 
@@ -224,7 +257,7 @@ CREATE TABLE `tb_core_mailcamp_config` (
   `mconfig_name` varchar(50) DEFAULT NULL,
   `mconfig_data` mediumtext DEFAULT NULL,
   `date` varchar(50) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE'.$DB_COLLATION.';
 
 -- --------------------------------------------------------
 
@@ -349,7 +382,7 @@ CREATE TABLE `tb_data_mailcamp_live` (
   `platform` mediumtext DEFAULT NULL,
   `device_type` mediumtext DEFAULT NULL,
   `all_headers` mediumtext DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE'.$DB_COLLATION.';
 
 -- --------------------------------------------------------
 
@@ -426,7 +459,7 @@ CREATE TABLE `tb_hf_list` (
   `file_original_name` varchar(111) DEFAULT NULL,
   `file_header` varchar(111) NOT NULL,
   `date` varchar(111) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE'.$DB_COLLATION.';
 
 -- --------------------------------------------------------
 
@@ -439,7 +472,7 @@ CREATE TABLE `tb_hland_page_list` (
   `page_name` mediumtext DEFAULT NULL,
   `page_file_name` varchar(111) DEFAULT NULL,
   `date` varchar(111) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE'.$DB_COLLATION.';
 
 -- --------------------------------------------------------
 
@@ -454,7 +487,7 @@ CREATE TABLE `tb_ht_list` (
   `file_extension` varchar(111) DEFAULT NULL,
   `file_header` varchar(111) DEFAULT NULL,
   `date` varchar(111) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE'.$DB_COLLATION.';
 
 -- --------------------------------------------------------
 
@@ -468,7 +501,7 @@ CREATE TABLE `tb_log` (
   `log` text DEFAULT NULL,
   `ip` varchar(55) DEFAULT NULL,
   `date` varchar(111) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE'.$DB_COLLATION.';
 
 -- --------------------------------------------------------
 
@@ -499,7 +532,7 @@ CREATE TABLE `tb_main` (
 CREATE TABLE `tb_main_cron` (
   `id` int(11) NOT NULL,
   `pid` int(111) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE'.$DB_COLLATION.';
 
 -- --------------------------------------------------------
 
@@ -514,7 +547,7 @@ CREATE TABLE `tb_main_variables` (
   `baseurl` varchar(111) DEFAULT NULL,
   `time_zone` varchar(111) DEFAULT NULL,
   `time_format` varchar(222) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE'.$DB_COLLATION.';
 
 -- --------------------------------------------------------
 
@@ -529,7 +562,7 @@ CREATE TABLE `tb_pl_list` (
   `pl_type` varchar(111) DEFAULT NULL,
   `pl_sub_type` varchar(111) DEFAULT NULL,
   `date` varchar(111) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE'.$DB_COLLATION.';
 
 -- --------------------------------------------------------
 
@@ -542,7 +575,7 @@ CREATE TABLE `tb_store` (
   `name` varchar(111) NOT NULL,
   `info` varchar(700) DEFAULT NULL,
   `content` mediumtext DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE'.$DB_COLLATION.';
 
 --
 -- Indexes for dumped tables


### PR DESCRIPTION
… issue on database engine

This commit fixes installer failures on MariaDB by removing hard-coded MySQL 8–only collations.

Key changes:
- Added automatic detection of MySQL vs MariaDB at install time
- Dynamically selects a compatible utf8mb4 collation
  - MariaDB / MySQL < 8 → utf8mb4_unicode_ci
  - MySQL 8+ → utf8mb4_0900_ai_ci
- Replaced hard-coded utf8mb4_0900_ai_ci usages in CREATE TABLE statements
- Ensured utf8mb4 charset is set on the database connection

This makes the installer portable across:
- MariaDB 10.x (including CloudLinux)
- MySQL 5.7
- MySQL 8+

No schema, data, or runtime logic changes beyond compatibility fixes.